### PR TITLE
implement tasaddmod and tasaddcategory commands

### DIFF
--- a/category_index.html
+++ b/category_index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>CELESTE Classic TAS Database</title>
+	<link rel="stylesheet" href="../../styles.css">
+	<link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
+</head>
+<body>
+	<div class="bootup">
+		<img src="../../p8logo.png"> <img src="../../maddy.png" style="height:1.5em"><br><br>
+        pico-8 0.2.0<br>
+        (c) 2014-20 lexaloffle games llp<br>
+        <br>
+    </div>
+	<div class="content">
+        > load {game_name}.p8<br />
+        <div style="color: #C2C3C7;">loaded {game_name}.p8 (26589 chars)</div>
+        > category = {'{category_name}', <div id="fulltime"></div>}
+        <hr>
+        <a href="../">../</a><br>
+        <table id="databaseTable" width="20%">
+
+        </table>
+		<br>
+                <a href="{zip_name}" download>Complete Download</a>
+    </div>
+<script src="../../database.js" defer></script>
+</body>
+</html>

--- a/cogs/tas.py
+++ b/cogs/tas.py
@@ -205,7 +205,7 @@ async def addGameToRepo(game, game_full_name, author):
 async def addCategory(game, category, category_full_name, level_name_data, author):
     level_names = []
     for line in level_name_data.splitlines():
-        level_name, file_name = line.split()
+        level_name, file_name = line.rsplit(maxsplit=1)
         level_names.append([level_name, file_name])
 
 

--- a/cogs/tas.py
+++ b/cogs/tas.py
@@ -15,78 +15,207 @@ import os
 import shutil
 from pathlib import Path
 import traceback
+from bs4 import BeautifulSoup
+import re
 
 VERIFICATION_CHANNEL_ID = 1121592306936578162
 
+class TasDatabase:
+    def __init__(self):
+        home = Path.home()
+        self.gitPath=home/'tasdatabase'
+        self.repo = git.Repo(self.gitPath)
+        self.repo.git.pull()
+        self.jsonPath=self.gitPath/'database.json'
+        with open(self.jsonPath,'r') as f:
+            self.data=json.load(f)
+
+    async def add_category(self, game, category, category_full_name, level_names):
+        #level_names is a list of pairs of (level_name, file_name)
+        self.data[game][category]=[]
+        for level_name,file_name in level_names:
+            self.data[game][category].append({
+                "name": level_name,
+                "file": file_name,
+                "frames": None
+            })
+        self.data["fulltime"][game][category] = None
+        await self.write_db()
+        category_path = self.gitPath/game/category
+        category_path.mkdir()
+        with open("category_index.html") as f:
+            category_html = f.read()
+
+        category_html = category_html.replace("{game_name}" ,game)
+        category_html = category_html.replace("{zip_name}" ,f"Full{game.capitalize()}{category.capitalize()}.zip")
+        category_html = category_html.replace("{category_name}" ,category_full_name)
+        with open(category_path / "index.html", "w") as f:
+            f.write(category_html)
+
+        with open(self.gitPath/game/"index.html", "r+") as f:
+            game_html = f.read()
+            soup = BeautifulSoup(game_html, features = "lxml")
+
+            new_tag = soup.new_tag("a", href=category)
+            new_tag.string = category_full_name
+
+            content_div = soup.find("div", {"class": "content"})
+            content_div.insert(-2, new_tag)
+            content_div.append(soup.new_tag("br"))
+
+            f.truncate(0)
+            f.seek(0)
+            f.write(soup.prettify())
+        self.repo.index.add([category_path / "index.html", self.gitPath/game/"index.html", self.jsonPath])
+
+
+
+    async def add_game(self, game, game_full_name):
+        self.data[game]={}
+        self.data["fulltime"][game] = {}
+        await self.write_db()
+
+        game_path = self.gitPath/game
+        game_path.mkdir()
+        with open("game_index.html") as f:
+            game_html = f.read()
+
+        game_html = game_html.replace("{game_name}", game)
+
+        with open(game_path/"index.html", "w") as f:
+            f.write(game_html)
+
+
+        with open(self.gitPath/"index.html", "r+") as f:
+            root_html = f.read()
+            soup = BeautifulSoup(root_html, features = "lxml")
+
+            link_tag = soup.find(string = re.compile("Mods")).find_next(["a", "div"])
+
+            # insert the new game in the correct place alphabetically
+            new_tag = soup.new_tag("a", href = game)
+            new_tag.string = game_full_name
+            while link_tag.name == "a":
+                if game < link_tag["href"]:
+                    link_tag.insert_before(new_tag, soup.new_tag("br"), "\n")
+                    break
+                link_tag = link_tag.find_next(["a", "div"])
+            else:
+                # if the new game is last alphabetically, insert it after the last game
+                link_tag = link_tag.find_previous("a").find_next("br")
+                link_tag.insert_after("\n", new_tag, soup.new_tag("br"))
+
+            f.truncate(0)
+            f.seek(0)
+            f.write(soup.prettify())
+
+        self.repo.index.add([self.jsonPath, self.gitPath/"index.html", game_path, game_path/"index.html"])
+
+    async def write_db(self):
+        with open(self.jsonPath,'w') as f:
+            json.dump(self.data, f, indent=4)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            return
+
+        #if there was an error - reset the working tree
+        print("resetting the repo")
+        self.repo.git.reset("--hard")
+        self.repo.git.clean("-df")
+
+
+
 # shoutouts to gonen
 async def updateAndCommit(tasfile, inputs, game, category, author):
-    home = str(Path.home())
-    gitPath=home+'/tasdatabase'
-    repo = git.Repo(gitPath)
     fileName = tasfile.filename
-    repo.git.pull()
-    #repo.git.fetch('--all')
-    #repo.git.reset('--hard', 'origin/master')
 
-    framecount=len(inputs)-1
-    dashnum=0
-    jumpnum=0
-    for i in inputs:
-        if i & 0x20:
-            dashnum += 1
-        elif i & 0x10:
-            jumpnum += 1
-
-    jsonPath=os.path.join(gitPath,'database.json')
-    with open(jsonPath,'r') as f:
-        data=json.load(f)
-
-    lvl_index = int(fileName.replace(".tas", "")[3:])
-    lvl_name = str(lvl_index) + '00m'
-
-    change={}
-    for lvl in data[game][category]:
-        if lvl['file']==fileName or lvl['name'] == lvl_name:
-            change=lvl
-
-    if not change:
-        change = data[game][category][lvl_index-1]
-    
-    oldframes = framecount
-    
-    if change['file'] == None:
-        change['file'] = fileName
-    else:
-        oldframes=change['frames']
-
-    
-    change['frames']=framecount
-    if 'dashes' in category:
-        change['dashes']=dashnum
-    if 'jumps' in category:
-        change['jumps']=jumpnum
-
-    with open(jsonPath, 'w') as f:
-        json.dump(data,f,indent=4)
-
-    rootPath = os.path.join(gitPath, game, category)
-
-    await tasfile.save(os.path.join(rootPath,fileName))
-    
+    async with TasDatabase() as tasdatabase:
+        framecount=len(inputs)-1
+        dashnum=0
+        jumpnum=0
+        for i in inputs:
+            if i & 0x20:
+                dashnum += 1
+            elif i & 0x10:
+                jumpnum += 1
 
 
-    zipPath=os.path.join(rootPath,f"Full{game.capitalize()}{category.capitalize()}.zip")
-    with zipfile.ZipFile(zipPath,"w") as zf:
-        for file in os.listdir(rootPath):
-            if file.endswith(".tas"):
-                zf.write(os.path.join(rootPath,file),os.path.join("TAS",file))
+        lvl_index = int(fileName.replace(".tas", "")[3:])
+        lvl_name = str(lvl_index) + '00m'
 
-    repo.index.add([os.path.join(rootPath,fileName),jsonPath,zipPath])
-   
-    commit_msg=f'updated {game} {category} {change["name"]} to be {framecount}f ({int(framecount)-int(oldframes):+}f) (automated)'
-    author = git.Actor(author, "celestebot@celesteclassic.github.io")
-    repo.index.commit(commit_msg, author=author)
-    repo.remotes.origin.push()
+        change={}
+        for lvl in tasdatabase.data[game][category]:
+            if lvl['file']==fileName or lvl['name'] == lvl_name:
+                change=lvl
+
+        if not change:
+            change = tasdatabase.data[game][category][lvl_index-1]
+
+        oldframes = framecount
+
+        if change['file'] == None:
+            change['file'] = fileName
+        else:
+            oldframes=change['frames']
+
+
+        change['frames']=framecount
+        if 'dashes' in category:
+            change['dashes']=dashnum
+        if 'jumps' in category:
+            change['jumps']=jumpnum
+
+        await tasdatabase.write_db()
+
+        rootPath = os.path.join(tasdatabase.gitPath, game, category)
+
+        await tasfile.save(os.path.join(rootPath,fileName))
+
+
+
+        zipPath=os.path.join(rootPath,f"Full{game.capitalize()}{category.capitalize()}.zip")
+        with zipfile.ZipFile(zipPath,"w") as zf:
+            for file in os.listdir(rootPath):
+                if file.endswith(".tas"):
+                    zf.write(os.path.join(rootPath,file),os.path.join("TAS",file))
+
+        tasdatabase.repo.index.add([os.path.join(rootPath,fileName), zipPath, tasdatabase.jsonPath])
+
+        if oldframes:
+            commit_msg=f'updated {game} {category} {change["name"]} to be {framecount}f ({int(framecount)-int(oldframes):+}f) (automated)'
+        else:
+            commit_msg=f'added {game} {category} {change["name"]} ({framecount}f) (automated)'
+
+        author = git.Actor(author, "celestebot@celesteclassic.github.io")
+        tasdatabase.repo.index.commit(commit_msg, author=author)
+        tasdatabase.repo.remotes.origin.push()
+
+async def addGameToRepo(game, game_full_name, author):
+    async with TasDatabase() as tasdatabase:
+        await tasdatabase.add_game(game, game_full_name)
+        commit_msg=f'added new game {game} (automated)'
+        author = git.Actor(author, "celestebot@celesteclassic.github.io")
+        tasdatabase.repo.index.commit(commit_msg, author=author)
+        tasdatabase.repo.remotes.origin.push()
+
+async def addCategory(game, category, category_full_name, level_name_data, author):
+    level_names = []
+    for line in level_name_data.splitlines():
+        level_name, file_name = line.split()
+        level_names.append([level_name, file_name])
+
+
+    async with TasDatabase() as tasdatabase:
+        await tasdatabase.add_category(game, category, category_full_name, level_names)
+        commit_msg=f'added new game {game} (automated)'
+        author = git.Actor(author, "celestebot@celesteclassic.github.io")
+        tasdatabase.repo.index.commit(commit_msg, author=author)
+        tasdatabase.repo.remotes.origin.push()
+
 
 """def run():
     process = subprocess.Popen("love ~/UniversalClassicTas/CelesteTAS/ &", stdout=subprocess.PIPE, shell=True)
@@ -129,7 +258,7 @@ class Tas(commands.Cog):
         self.bot = bot
         self.submitted_tases = []
 
-    
+
     @commands.command(aliases=["updatetas", "sendtas"])
     async def uploadtas(self, ctx, game, category):
         if len(ctx.message.attachments) > 0:
@@ -142,10 +271,10 @@ class Tas(commands.Cog):
                     await ctx.send("TAS File uploaded (probably)!")
                 else:
                     new_sub = TasSubmission(ctx.message.attachments[0], inputs, game, category, ctx.author.name, level, ctx.message)
-                    
+
                     self.submitted_tases.append(new_sub)
                     await ctx.send("TAS File sent for verification!")
-                    embed = discord.Embed(title="New TAS waiting for verification", 
+                    embed = discord.Embed(title="New TAS waiting for verification",
                             description=str(new_sub) +
                                         f"\n[Click here to download the .tas]({ctx.message.attachments[0].url})",
                             color=0x00E436)
@@ -179,14 +308,14 @@ class Tas(commands.Cog):
         tas_list = ""
         for tas in self.submitted_tases:
             tas_list += f"- {tas}\n"
-        
+
         await ctx.send("The following TASes have not yet been verified:\n" + tas_list)
 
     @commands.command()
     async def tas(self, ctx, game, category, *, levelname):
         r = requests.get(f"https://celesteclassic.github.io/tasdatabase/database.json")
 
-        
+
         if levelname.isdigit() and not levelname.startswith("m"):
             levelname+="m"
         try:
@@ -199,7 +328,7 @@ class Tas(commands.Cog):
         for level in j:
 
             if level["name"].lower() == levelname.lower():
-            
+
                 frames = level["frames"]
                 name = level["name"]
                 filename = level["file"]
@@ -213,6 +342,33 @@ class Tas(commands.Cog):
 
                 await ctx.send(embed=embed)
                 break
+
+    @commands.command()
+    async def tasaddmod(self, ctx, game, full_game_name):
+        if (self.is_tas_verifier(ctx)):
+            try:
+                await addGameToRepo(game, full_game_name, ctx.author.name)
+                await ctx.send("Mod added to db (probably)!")
+            except:
+                traceback.print_exc()
+                await ctx.send("Something went wrong while adding the mod (tell cominixo)")
+
+
+    @commands.command()
+    async def tasaddcategory(self, ctx, game, category, full_category_name):
+        if len(ctx.message.attachments) > 0:
+            if (self.is_tas_verifier(ctx)):
+                try:
+                    level_name_data = (await ctx.message.attachments[0].read()).decode('utf-8')
+                    await addCategory(game, category, full_category_name, level_name_data, ctx.author.name)
+                    await ctx.send("category added to db (probably)!")
+                except:
+                    traceback.print_exc()
+                    await ctx.send("Something went wrong while adding the category (tell cominixo)")
+        else:
+            await ctx.send("Please include a file containing the level and corrosponding file names")
+
+
 
 async def setup(bot):
     await bot.add_cog(Tas(bot))

--- a/cogs/tas.py
+++ b/cogs/tas.py
@@ -211,7 +211,7 @@ async def addCategory(game, category, category_full_name, level_name_data, autho
 
     async with TasDatabase() as tasdatabase:
         await tasdatabase.add_category(game, category, category_full_name, level_names)
-        commit_msg=f'added new game {game} (automated)'
+        commit_msg=f'added new category {category} to {game} (automated)'
         author = git.Actor(author, "celestebot@celesteclassic.github.io")
         tasdatabase.repo.index.commit(commit_msg, author=author)
         tasdatabase.repo.remotes.origin.push()

--- a/game_index.html
+++ b/game_index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>CELESTE Classic TAS Database</title>
+	<link rel="stylesheet" href="../styles.css">
+	<link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
+</head>
+<body>
+	<div class="bootup">
+		<img src="../p8logo.png"> <img src="../maddy.png" style="height:1.5em"><br><br>
+        pico-8 0.2.0<br>
+        (c) 2014-20 lexaloffle games llp<br>
+        <br>
+    </div>
+	<div class="content">
+        > load {game_name}.p8<br />
+        <div style="color: #C2C3C7;">loaded {game_name}.p8 (26589 chars)</div>
+        <hr>
+        <a href="../">../</a><br>
+        <br>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Implemented 2 new commands:
`tasaddmod` - adds a mod to the tas db. usage is like `tasaddmod my_mod "My Cool Mod"`
`tasaddcategory` - adds a category to a specific mod. usage is like `tasaddcategory my_mod my_category "My Cool Category"` - and attached to the message there needs to be a file matching between level names and filenames - like
```
100m TAS1.tas
200m TAS2.tas
300m TAS3.tas
hello TAS100.tas
goodbyte TAS4.tas
```
only verifiers can use these 2 commands 

in addition - slightly refactored all the tasdb code, and threw it into its own class (though it still isn't the cleanest)
if these commands fail - they should discard all changes to the tasdatabase on disk

stuff I didn't consider that's maybe worth considering?
* race conditions on accesses to the db (idk if the bot can handle multiple commands at once - but if it can, might be worth throwing a lock on the tasdb object)
* a bit more sanitization of user input
* some form of user interaction/verfication of the commands (i.e. after a user tries to add a command - send a message saying what game/category/levels wil be added - and ask the user to confirm)

also missing some old nice but slightly niche features
the full time of the mods is just left empty for now
very very niche - but for old mods - the db file contained a line `loaded mod.p8 (xxx chars)` where xxx is the actual char count of the cart - and now its just hardcoded